### PR TITLE
website: open gaufre links in new tab

### DIFF
--- a/website/src/components/GaufrePage.astro
+++ b/website/src/components/GaufrePage.astro
@@ -223,7 +223,7 @@ const { services } = Astro.props
                         ) : null}
                       </div>
                       <a
-                        target="_parent"
+                        target="_blank"
                         class="lagaufre-service__name"
                         href={url}
                         id={`lagaufre-service-${id}`}


### PR DESCRIPTION
## Description 
The original way was to open the link in the current window. Which sound consistent with the use case of the Gaufre (switching between apps). But for some apps like Tchap, it is really weird to replace all the windows and not opening the new app in a tab

I think there is multiple approach to implement this :
- Let each product the possibility to define how they want to link to open
- Impose one way of working so that it is a standard for all product

## Changes 
Open the gaufre's link in a new tab. In our opinion this behavior is more standard with current market web product