### PR TITLE
🐛(lagaufre) use accessibleName for service aria-label

### DIFF
--- a/packages/integration/CHANGELOG.md
+++ b/packages/integration/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 - header and footer are displayed by default in mobile mode, but never in desktop mode.
 - show only the first x (customizable) services and add view_more button
-
-
+- lagaufre: use optional `accessibleName` for service `aria-label` (short display name, full accessible name)
 
 ## 1.0.3
 

--- a/packages/widgets/src/widgets/lagaufre/main.ts
+++ b/packages/widgets/src/widgets/lagaufre/main.ts
@@ -9,6 +9,7 @@ const widgetName = "lagaufre";
 
 type Service = {
   name: string;
+  accessibleName?: string;
   url: string;
   maturity?: string;
   logo?: string;
@@ -233,7 +234,9 @@ listenEvent(widgetName, "init", null, false, async (args: GaufreWidgetArgs) => {
 
       anchor.setAttribute(
         "aria-label",
-        service.name + (service.maturity ? ` (${service.maturity})` : "") + (args.newWindowLabelSuffix || ""),
+        (service.accessibleName || service.name) +
+          (service.maturity ? ` (${service.maturity})` : "") +
+          (args.newWindowLabelSuffix || ""),
       );
       anchor.href = service.url;
       img.src = service.logo;

--- a/website/src/components/GaufrePage.astro
+++ b/website/src/components/GaufrePage.astro
@@ -315,12 +315,12 @@ const useSubsettedFont = import.meta.env.PUBLIC_USE_GAUFRE_SUBSETTED_FONT !== "0
         {
           services
             .filter(({ enabled }) => !!enabled)
-            .map(({ id, name, url, beta }, i: number) => {
+            .map(({ id, name, accessibleName, url, beta }, i: number) => {
               const logo =
                 logos[`/src/assets/logos/${id}.svg`] ||
                 logos[`/src/assets/logos/${id}.jpg`] ||
                 logos[`/src/assets/logos/${id}.png`]
-              const ariaLabel = `${name} ${!!beta ? "(bêta)" : ""} - nouvelle fenêtre`
+              const ariaLabel = `${accessibleName || name} ${!!beta ? "(bêta)" : ""} - nouvelle fenêtre`
               return (
                 <li>
                   <div class="lagaufre-service lagaufre-enlarge-link">

--- a/website/src/data/services.json
+++ b/website/src/data/services.json
@@ -52,6 +52,7 @@
   {
     "id": "france-transfert",
     "name": "France Transfert",
+    "accessibleName": "France Transfert",
     "url": "https://francetransfert.numerique.gouv.fr/upload",
     "tagline": "**France Transfert** permet d’envoyer des fichiers <br>volumineux non sensibles de manière sécurisée <br>à un agent de l’Etat ou entre agents",
     "homepageType": "custom",

--- a/website/src/pages/api/v1/services.json.ts
+++ b/website/src/pages/api/v1/services.json.ts
@@ -8,6 +8,7 @@ export async function GET() {
         .map((service) => ({
           id: service.id,
           name: service.name,
+          ...("accessibleName" in service && { accessibleName: service.accessibleName }),
           url: service.url,
         })),
     ),


### PR DESCRIPTION
## Purpose

Use the full accessible name for France Transfert in the La Suite app switcher ([#49](https://github.com/suitenumerique/integration/issues/49)). The landing page API can keep a short display name (`Fr. Transfert`) while screen readers announce the full service name.

## Proposal

* [x] Add optional `accessibleName` to the lagaufre widget `Service` type
* [x] Use `accessibleName || name` for `aria-label` in lagaufre v2
* [x] Apply the same logic in gaufre v1 (`GaufrePage.astro`)
* [x] Expose `accessibleName` from `/api/v1/services.json` when present